### PR TITLE
refactor(api): Remove Binance API key and secret requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,4 @@
 # Binance API Configuration
-BINANCE_API_KEY=your_binance_api_key_here
-BINANCE_SECRET_KEY=your_binance_secret_key_here
 BINANCE_BASE_URL=https://api.binance.com
 
 # Redis Configuration

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ chmod +x run.sh
 
 # Or run directly:
 # Windows:
-tet-data-service-windows-amd64.exe --api-key=your_key --secret-key=your_secret
+tet-data-service-windows-amd64.exe
 
 # Linux:
-./tet-data-service-linux-amd64 --api-key=your_key --secret-key=your_secret
+./tet-data-service-linux-amd64
 
 # macOS:
-./tet-data-service-darwin-amd64 --api-key=your_key --secret-key=your_secret
+./tet-data-service-darwin-amd64
 ```
 
 ### Method 2: Using Docker (Recommended for Production)
@@ -76,10 +76,11 @@ cd tet-data-service
 cp .env.example .env
 ```
 
-2. Edit `.env` file with your Binance API credentials:
+2. (Optional) Adjust `.env` with your preferred settings:
 ```bash
-BINANCE_API_KEY=your_api_key_here
-BINANCE_SECRET_KEY=your_secret_key_here
+# Example overrides
+BINANCE_BASE_URL=https://api.binance.com
+TIMEFRAME=15m
 ```
 
 3. Start the service:
@@ -115,8 +116,7 @@ All configuration is handled through environment variables. See `.env.example` f
 - `TIMEFRAME`: Kline timeframe - 15m, 30m, 1h, 2h, 4h, 1d (default: 15m)
 
 ### API Configuration
-- `BINANCE_API_KEY`: Your Binance API key (required)
-- `BINANCE_SECRET_KEY`: Your Binance secret key (required)
+- `BINANCE_BASE_URL`: Binance API base URL (default: https://api.binance.com)
 - `API_REQUESTS_PER_SEC`: API rate limit (default: 15/second)
 
 ### Redis Configuration
@@ -132,8 +132,6 @@ All configuration is handled through environment variables. See `.env.example` f
 ./tet-data-service-platform-arch [options]
 
 Options:
-  --api-key string       Binance API Key (required)
-  --secret-key string    Binance Secret Key (required)
   --redis string         Redis server address (default "localhost:6379")
   --redis-db int         Redis database number (default 1)
   --interval int         Update interval in seconds (default 180)
@@ -313,7 +311,7 @@ The service includes comprehensive error handling:
 
 ## Security Considerations
 
-- **API Keys**: Store securely using environment variables or secrets management
+- **Public Data Only**: Service relies on Binance public endpoints; API keys are not required
 - **Redis**: Configure authentication if accessible externally
 - **Network**: Use VPC/firewall rules to restrict access
 - **Monitoring**: Log access attempts and API usage
@@ -329,19 +327,15 @@ This project is part of the TET Framework - check the main project for licensing
 #### Basic Usage
 ```bash
 # Windows - Basic setup
-tet-data-service-windows-amd64.exe --api-key=your_key --secret-key=your_secret
+tet-data-service-windows-amd64.exe
 
 # Linux - Remote Redis
 ./tet-data-service-linux-amd64 \
-  --api-key=your_key \
-  --secret-key=your_secret \
   --redis=192.168.1.100:6379 \
   --redis-db=2
 
 # Custom symbols and timeframe
 ./tet-data-service-linux-amd64 \
-  --api-key=your_key \
-  --secret-key=your_secret \
   --symbols="BTC/USDT,ETH/USDT,BNB/USDT" \
   --timeframe=5m \
   --interval=60
@@ -351,8 +345,8 @@ tet-data-service-windows-amd64.exe --api-key=your_key --secret-key=your_secret
 ```bash
 # Run in background (Linux)
 nohup ./tet-data-service-linux-amd64 \
-  --api-key=your_key \
-  --secret-key=your_secret > tet-service.log 2>&1 &
+  --redis=localhost:6379 \
+  --interval=180 > tet-service.log 2>&1 &
 
 # Create systemd service
 sudo systemctl enable tet-data-service
@@ -362,9 +356,8 @@ sudo systemctl start tet-data-service
 #### Configuration File Method
 ```bash
 # Create config.txt with your settings
-echo "BINANCE_API_KEY=your_key" > config.txt
-echo "BINANCE_SECRET_KEY=your_secret" >> config.txt
-echo "REDIS_ADDR=localhost:6379" >> config.txt
+echo "REDIS_ADDR=localhost:6379" > config.txt
+echo "TIMEFRAME=15m" >> config.txt
 
 # Run with config file
 ./tet-data-service-linux-amd64 --config=config.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,7 @@ services:
     container_name: tet-data-service
     restart: unless-stopped
     environment:
-      - BINANCE_API_KEY=${BINANCE_API_KEY}
-      - BINANCE_SECRET_KEY=${BINANCE_SECRET_KEY}
+      - BINANCE_BASE_URL=${BINANCE_BASE_URL:-https://api.binance.com}
       - REDIS_ADDR=redis:6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
       - REDIS_DB=${REDIS_DB:-1}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,9 +12,7 @@ import (
 
 type Config struct {
 	// Binance API配置
-	BinanceAPIKey    string
-	BinanceSecretKey string
-	BinanceBaseURL   string
+	BinanceBaseURL string
 
 	// Redis配置
 	RedisAddr     string
@@ -82,14 +80,6 @@ func Load(configPath string) (*Config, error) {
 		SuccessRecoveryRate:      getEnvFloat("SUCCESS_RECOVERY_RATE", 0.9),
 		MarketHoursOptimization:  getEnvBool("MARKET_HOURS_OPTIMIZATION", true),
 		OffPeakMultiplier:        getEnvFloat("OFF_PEAK_MULTIPLIER", 2.0),
-	}
-
-	// 必需的配置项检查
-	cfg.BinanceAPIKey = os.Getenv("BINANCE_API_KEY")
-	cfg.BinanceSecretKey = os.Getenv("BINANCE_SECRET_KEY")
-
-	if cfg.BinanceAPIKey == "" || cfg.BinanceSecretKey == "" {
-		return nil, fmt.Errorf("BINANCE_API_KEY and BINANCE_SECRET_KEY must be set")
 	}
 
 	// 加载交易对列表

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -43,8 +43,6 @@ type ResourceUsage struct {
 func New(cfg *config.Config) (*DataUpdater, error) {
 	// 创建Binance客户端
 	binanceClient := binance.NewClient(
-		cfg.BinanceAPIKey,
-		cfg.BinanceSecretKey,
 		cfg.BinanceBaseURL,
 		cfg.APIRequestsPerSec,
 	)

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -39,9 +39,8 @@ cp config.example config.txt
 
 编辑 `config.txt` 文件，设置必要的配置：
 ```ini
-# 必须设置的 Binance API 凭据
-BINANCE_API_KEY=你的API密钥
-BINANCE_SECRET_KEY=你的密钥密码
+# Binance 接口（公共行情数据无需密钥）
+BINANCE_BASE_URL=https://api.binance.com
 
 # Redis 连接（默认本地）
 REDIS_ADDR=localhost:6379
@@ -73,25 +72,23 @@ chmod +x run.sh
 
 **Windows:**
 ```bash
-tet-data-service-windows-amd64.exe --api-key=你的密钥 --secret-key=你的密码
+tet-data-service-windows-amd64.exe
 ```
 
 **Linux:**
 ```bash
-./tet-data-service-linux-amd64 --api-key=你的密钥 --secret-key=你的密码
+./tet-data-service-linux-amd64
 ```
 
 **macOS:**
 ```bash
-./tet-data-service-darwin-amd64 --api-key=你的密钥 --secret-key=你的密码
+./tet-data-service-darwin-amd64
 ```
 
 ## 命令行参数
 
 | 参数 | 默认值 | 说明 |
 |------|--------|------|
-| `--api-key` | - | Binance API Key (必需) |
-| `--secret-key` | - | Binance Secret Key (必需) |
 | `--redis` | localhost:6379 | Redis 服务器地址 |
 | `--redis-db` | 1 | Redis 数据库编号 |
 | `--interval` | 180 | 更新间隔（秒） |
@@ -106,14 +103,12 @@ tet-data-service-windows-amd64.exe --api-key=你的密钥 --secret-key=你的密
 
 ```bash
 # Windows
-set BINANCE_API_KEY=你的密钥
-set BINANCE_SECRET_KEY=你的密码
 set REDIS_ADDR=localhost:6379
+set TIMEFRAME=15m
 
 # Linux/macOS
-export BINANCE_API_KEY=你的密钥
-export BINANCE_SECRET_KEY=你的密码
 export REDIS_ADDR=localhost:6379
+export TIMEFRAME=15m
 ```
 
 ## 使用示例
@@ -125,8 +120,6 @@ export REDIS_ADDR=localhost:6379
 
 # 使用命令行参数
 ./tet-data-service-linux-amd64 \
-  --api-key=你的密钥 \
-  --secret-key=你的密码 \
   --redis=localhost:6379 \
   --interval=120
 ```
@@ -135,8 +128,6 @@ export REDIS_ADDR=localhost:6379
 ```bash
 # 自定义交易对和更新频率
 ./tet-data-service-linux-amd64 \
-  --api-key=你的密钥 \
-  --secret-key=你的密码 \
   --symbols="BTC/USDT,ETH/USDT,BNB/USDT" \
   --interval=60 \
   --concurrent=20 \
@@ -147,8 +138,6 @@ export REDIS_ADDR=localhost:6379
 ```bash
 # 连接到远程 Redis 服务器
 ./tet-data-service-linux-amd64 \
-  --api-key=你的密钥 \
-  --secret-key=你的密码 \
   --redis=192.168.1.100:6379 \
   --redis-db=2
 ```
@@ -184,9 +173,8 @@ Type=simple
 User=your-user
 WorkingDirectory=/path/to/tet-data-service
 ExecStart=/path/to/tet-data-service/tet-data-service-linux-amd64
-Environment=BINANCE_API_KEY=你的密钥
-Environment=BINANCE_SECRET_KEY=你的密码
 Environment=REDIS_ADDR=localhost:6379
+Environment=TIMEFRAME=15m
 Restart=always
 RestartSec=5
 
@@ -241,21 +229,17 @@ GET tet:system:status
 
 ### 常见问题
 
-1. **API 密钥错误**
-   - 确保 API 密钥和密码正确
-   - 检查 Binance API 权限设置
-
-2. **Redis 连接失败**
+1. **Redis 连接失败**
    - 确保 Redis 服务正在运行
    - 检查 Redis 地址和端口
    - 验证 Redis 访问权限
 
-3. **网络连接问题**
+2. **网络连接问题**
    - 检查网络连接到 Binance API
    - 确认防火墙设置
    - 如果在中国大陆，可能需要使用代理
 
-4. **权限问题**
+3. **权限问题**
    - 确保可执行文件有执行权限
    - Linux/macOS 用户运行: `chmod +x tet-data-service-*`
 
@@ -263,7 +247,7 @@ GET tet:system:status
 
 添加详细日志输出：
 ```bash
-./tet-data-service-linux-amd64 --api-key=你的密钥 --secret-key=你的密码 -v
+./tet-data-service-linux-amd64 -v
 ```
 
 ## 性能优化

--- a/standalone/config.example
+++ b/standalone/config.example
@@ -4,9 +4,8 @@
 # ===================
 # Binance API 配置
 # ===================
-# 在 https://www.binance.com/zh-CN/my/settings/api-management 获取
-BINANCE_API_KEY=your_binance_api_key_here
-BINANCE_SECRET_KEY=your_binance_secret_key_here
+# 公共行情数据无需 API 密钥
+BINANCE_BASE_URL=https://api.binance.com
 
 # ===================
 # Redis 配置

--- a/standalone/run.bat
+++ b/standalone/run.bat
@@ -21,9 +21,8 @@ if not exist "config.txt" (
     copy config.example config.txt
     echo.
     echo Please edit config.txt with your settings:
-    echo 1. Set your Binance API Key and Secret Key
-    echo 2. Configure Redis connection settings
-    echo 3. Adjust update parameters as needed
+    echo 1. Configure Redis connection settings
+    echo 2. Adjust update parameters as needed
     echo.
     echo Opening config.txt for editing...
     notepad config.txt
@@ -64,8 +63,6 @@ for /f "usebackq tokens=1,2 delims==" %%a in ("config.txt") do (
 
 :: 启动程序
 tet-data-service-windows-amd64.exe ^
-    --api-key=%BINANCE_API_KEY% ^
-    --secret-key=%BINANCE_SECRET_KEY% ^
     --redis=%REDIS_ADDR% ^
     --redis-db=%REDIS_DB% ^
     --interval=%UPDATE_INTERVAL% ^

--- a/standalone/run.sh
+++ b/standalone/run.sh
@@ -47,9 +47,8 @@ if [ ! -f "config.txt" ]; then
     cp config.example config.txt
     echo ""
     echo "Please edit config.txt with your settings:"
-    echo "1. Set your Binance API Key and Secret Key"
-    echo "2. Configure Redis connection settings"
-    echo "3. Adjust update parameters as needed"
+    echo "1. Configure Redis connection settings"
+    echo "2. Adjust update parameters as needed"
     echo ""
     echo "You can edit the file with:"
     echo "  nano config.txt    (or vim, gedit, etc.)"
@@ -92,14 +91,6 @@ echo ""
 
 # 构建命令行参数
 ARGS=""
-
-if [ ! -z "$BINANCE_API_KEY" ]; then
-    ARGS="$ARGS --api-key=$BINANCE_API_KEY"
-fi
-
-if [ ! -z "$BINANCE_SECRET_KEY" ]; then
-    ARGS="$ARGS --secret-key=$BINANCE_SECRET_KEY"
-fi
 
 if [ ! -z "$REDIS_ADDR" ]; then
     ARGS="$ARGS --redis=$REDIS_ADDR"


### PR DESCRIPTION
This commit removes the need for Binance API and secret keys, as the service only utilizes public endpoints to fetch market data (klines). This change simplifies the setup process and enhances security by eliminating the need for users to manage sensitive credentials.

- Removed API key and secret from all configuration layers, including environment variables (`.env.example`), command-line flags, and internal config structs.
- Refactored the Binance client to remove all request signing logic (HMAC-SHA256) and the `X-MBX-APIKEY` header.
- Updated all calls to the request sending function to reflect that requests are no longer signed.
- Updated `README.md` to remove all references to API keys, simplifying usage examples and security considerations.